### PR TITLE
Boardが削除されると紐づくCardも削除されるように改修　close#29

### DIFF
--- a/KPTer/BoardViewModel.swift
+++ b/KPTer/BoardViewModel.swift
@@ -24,6 +24,9 @@ class BoardViewModel {
     class func delete(board: Board){
         let realm = try! Realm()
         try! realm.write {
+            for var i = board.cards.count - 1; i >= 0; i-- {
+                realm.delete(board.cards.first!)
+            }
             realm.delete(board)
         }
     }
@@ -36,7 +39,11 @@ class BoardViewModel {
     }
     
     class func addCard(board: Board, title: String, detail: String) {
-        //board.cards.append(CardViewModel.create(title, detail: detail)!)
+        let card = CardViewModel.create(title, detail: detail)
+        let realm = try! Realm()
+        try! realm.write {
+            board.cards.append(card!)
+        }
     }
 
 }

--- a/KPTer/CardViewModel.swift
+++ b/KPTer/CardViewModel.swift
@@ -27,4 +27,11 @@ class CardViewModel {
             card.card_title = title
         }
     }
+    
+    class func delete(card: Card){
+        let realm = try! Realm()
+        try! realm.write {
+            realm.delete(card)
+        }
+    }
 }

--- a/KPTerTests/BoardSpec.swift
+++ b/KPTerTests/BoardSpec.swift
@@ -12,6 +12,7 @@ import Quick
 import Nimble
 @testable import KPTer
 
+// BoardViewModelのテストをする際は、CardSpecのspec()内をコメントアウトしてください。
 class BoardSpec: QuickSpec {
     
     override func spec() {
@@ -21,6 +22,7 @@ class BoardSpec: QuickSpec {
             realm.deleteAll()
         }
         var newBoard: Board? = BoardViewModel.create("new board title")
+        //BoardViewModel.addCard(newBoard!, title: "newBoard card title", detail: "newBoard card detail")
         
         describe("新規Boardを作成する") {
             it("新規Boardを作成できること") {
@@ -30,35 +32,36 @@ class BoardSpec: QuickSpec {
                 expect(newBoard!.board_title).to(equal("new board title"))
             }
         }
-        
+
         describe("Cardの名前を引数に指定し、Boardに紐付いたCardを作成する") {
             sleep(2)
             BoardViewModel.addCard(newBoard!, title: "new card title", detail: "new card detail")
+            BoardViewModel.addCard(newBoard!, title: "new card title2", detail: "new card detail")
             
             it("Boardに紐付いたCardが取得できること") {
                 expect(newBoard!.cards).toNot(beNil())
             }
             
         }
-        
+
         describe("既存のBoardを編集する") {
             sleep(2)
             it("Boardの名前を引数に指定し、Boardの名前を変更できること") {
-                
                 BoardViewModel.edit(newBoard!, title: "edit board title", detail: "edit board detail")
                 let editBoard: Board? = realm.objects(Board).first
                 expect(editBoard!.board_title).to(equal("edit board title"))
             }
         }
-        
-        // ↓があると、Cardのテストが通らないため、一時的にコメントアウト
-        //describe("Boardを削除する") {
-          //  sleep(10)
-            //it("削除されたBoardが取得できないこと") {
-              //  newBoard!.deleteBoard()
-                //expect(Board.MR_findAll()?.count).to(equal(0))
-            //}
-        //}
+
+        describe("Boardを削除する") {
+            
+            it("削除されたBoardが取得できないこと/削除されたBoardに紐づくcardsが取得できないこと") {
+                sleep(10)
+                BoardViewModel.delete(newBoard!)
+                expect(realm.objects(Board).count).to(equal(0)) //削除されたBoardが取得できないこと
+                expect(realm.objects(Card).count).to(equal(0))  //削除されたBoardに紐づくcardsが取得できないこと
+            }
+        }
     }
 }
  

--- a/KPTerTests/CardSpec.swift
+++ b/KPTerTests/CardSpec.swift
@@ -4,6 +4,7 @@ import Quick
 import Nimble
 @testable import KPTer
 
+// CardViewModelのテストをする際は、BoardSpecのspec()内をコメントアウトしてください。
 class CardSpec: QuickSpec {
     override func spec() {
         
@@ -28,6 +29,16 @@ class CardSpec: QuickSpec {
                 expect(editCard!.card_title).to(equal("edit card title"))
             }
         }
+        
+        describe("Cardを削除する") {
+            
+            it("削除されたCardが取得できないこと") {
+                sleep(10)
+                CardViewModel.delete(newCard!)
+                expect(realm.objects(Card).count).to(equal(0)) //削除されたCardが取得できないこと
+            }
+        }
+
         
     }
 }

--- a/KPTerTests/CardSpec.swift
+++ b/KPTerTests/CardSpec.swift
@@ -35,7 +35,7 @@ class CardSpec: QuickSpec {
             it("削除されたCardが取得できないこと") {
                 sleep(10)
                 CardViewModel.delete(newCard!)
-                expect(realm.objects(Card).count).to(equal(0)) //削除されたCardが取得できないこと
+                expect(realm.objects(Card).count).to(equal(0)) 
             }
         }
 


### PR DESCRIPTION
- CardViewModelにdelete()を実装
- Boardが削除されたら、紐づくCardが削除されるように改修

おねがいしまーーーーす！

[参考URL（realm-java）](https://github.com/realm/realm-java/issues/899)
