### PR TITLE
cardのrelationを削除するメソッドを実装

### DIFF
--- a/KPTer/BoardViewModel.swift
+++ b/KPTer/BoardViewModel.swift
@@ -64,7 +64,7 @@ class BoardViewModel {
     
     class func addTryCard(board: Board, title: String, detail: String, fromCard: Card) {
         let card = BoardViewModel.addCard(board, title: title, detail: detail, type: Card.CardType.Try)
-        addCardRelation(fromCard.id, toId: card.id)
+        CardViewModel.addCardRelation(fromCard.id, toId: card.id)
     }
     
     private class func addCard(board: Board, title: String, detail: String, type: Card.CardType) -> Card{
@@ -95,16 +95,6 @@ class BoardViewModel {
     // Boardに紐づくCardをタイプ別に取得する
     private class func findCardByType(board: Board, type: Card.CardType) -> Results<Card> {
         return board.cards.filter("type = '\(type.rawValue)'").sorted("order")
-    }
-    
-    private class func addCardRelation(fromId: String, toId: String) {
-        let cardRelation = CardRelation()
-        cardRelation.from_id = fromId
-        cardRelation.to_id = toId
-        let realm = try! Realm()
-        try! realm.write {
-            realm.add(cardRelation)
-        }
     }
     
     class func changeCardOrder(results: Results<Card>, from_card_row: Int, to_card_row: Int) {

--- a/KPTer/CardViewModel.swift
+++ b/KPTer/CardViewModel.swift
@@ -40,6 +40,24 @@ class CardViewModel {
         }
     }
     
+    class func addCardRelation(fromId: String, toId: String) {
+        let cardRelation = CardRelation()
+        cardRelation.from_id = fromId
+        cardRelation.to_id = toId
+        let realm = try! Realm()
+        try! realm.write {
+            realm.add(cardRelation)
+        }
+    }
+    
+    class func deleteCardRelation(tryCard: Card) {
+        let realm = try! Realm()
+        let cardRelation = realm.objects(CardRelation).filter("to_id = '\(tryCard.id)'")
+        try! realm.write {
+            realm.delete(cardRelation)
+        }
+    }
+    
     class func changeStatus(card: Card, status: Card.CardStatus){
         let realm = try! Realm()
         try! realm.write {

--- a/KPTerTests/CardSpec.swift
+++ b/KPTerTests/CardSpec.swift
@@ -12,7 +12,9 @@ class CardSpec: QuickSpec {
         try! realm.write {
             realm.deleteAll()
         }
+        var newBoard: Board? = BoardViewModel.create("new board title")
         var newCard: Card? = CardViewModel.create("new card title", detail: "new card detail", type: Card.CardType.Keep)
+        BoardViewModel.addTryCard(newBoard!, title: "new card title2", detail: "new card detail2", fromCard: newCard!)
         
         describe("新規Cardを作成する") {
             it("新規Cardを作成できること") {
@@ -61,8 +63,9 @@ class CardSpec: QuickSpec {
             
             it("削除されたCardが取得できないこと") {
                 sleep(7)
-                CardViewModel.delete(newCard!)
-                expect(realm.objects(Card).count).to(equal(0)) 
+                CardViewModel.delete(BoardViewModel.findTryCard(newBoard!).first!)
+                expect(realm.objects(Card).count).to(equal(1))
+                expect(realm.objects(CardRelation).count).to(equal(1))
             }
         }
         

--- a/KPTerTests/CardSpec.swift
+++ b/KPTerTests/CardSpec.swift
@@ -15,6 +15,7 @@ class CardSpec: QuickSpec {
         var newBoard: Board? = BoardViewModel.create("new board title")
         var newCard: Card? = CardViewModel.create("new card title", detail: "new card detail", type: Card.CardType.Keep)
         BoardViewModel.addTryCard(newBoard!, title: "new card title2", detail: "new card detail2", fromCard: newCard!)
+        BoardViewModel.addProblemCard(newBoard!, title: "new card title2", detail: "new card detail2")
         
         describe("新規Cardを作成する") {
             it("新規Cardを作成できること") {
@@ -63,9 +64,10 @@ class CardSpec: QuickSpec {
             
             it("削除されたCardが取得できないこと") {
                 sleep(7)
-                CardViewModel.delete(BoardViewModel.findTryCard(newBoard!).first!)
-                expect(realm.objects(Card).count).to(equal(1))
-                expect(realm.objects(CardRelation).count).to(equal(1))
+                CardViewModel.deleteCardRelation(BoardViewModel.findTryCard(newBoard!).first!)
+                CardViewModel.delete(BoardViewModel.findTryCard(newBoard!).first!)                
+                expect(realm.objects(Card).count).to(equal(2))
+                expect(realm.objects(CardRelation).count).to(equal(0))
             }
         }
         


### PR DESCRIPTION
Fixes #55.

Changes proposed in this pull request:
- deleteCardRelationメソッドを実装
- addCardRelationメソッドをCardViewModelにおひっこし
- CardSpec.swiftにテストの記述

@HanaLucky/KPTer
