### PR TITLE
カード画面：Tryカードの追加処理

### DIFF
--- a/KPTer/Base.lproj/Main.storyboard
+++ b/KPTer/Base.lproj/Main.storyboard
@@ -270,6 +270,8 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="cardRelationLabel" destination="p5E-N8-fBU" id="znI-PB-T3k"/>
+                        <outlet property="cardTypeSegumentedControl" destination="4CU-H5-0tI" id="83t-yR-BFX"/>
                         <outlet property="descriptionField" destination="r8B-uR-7hS" id="TWN-AM-qWp"/>
                         <outlet property="relationCardTableView" destination="ozq-M2-yuL" id="5Ya-t9-Udm"/>
                         <outlet property="titleField" destination="ou0-ID-tNs" id="2e6-bz-lfH"/>

--- a/KPTer/Base.lproj/Main.storyboard
+++ b/KPTer/Base.lproj/Main.storyboard
@@ -158,7 +158,7 @@
                                 </items>
                             </navigationBar>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r8B-uR-7hS" customClass="UIDescriptionTextView" customModule="KPTer" customModuleProvider="target">
-                                <rect key="frame" x="16" y="219" width="568" height="190"/>
+                                <rect key="frame" x="16" y="219" width="568" height="161"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -167,7 +167,7 @@
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="4CU-H5-0tI" userLabel="CardType">
                                 <rect key="frame" x="194" y="87" width="212" height="29"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="212" id="BsP-HV-MsO"/>
+                                    <constraint firstAttribute="width" constant="212" id="ktG-Y1-QhI"/>
                                 </constraints>
                                 <segments>
                                     <segment title="Keep"/>
@@ -190,44 +190,71 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ozq-M2-yuL">
                                 <rect key="frame" x="16" y="417" width="568" height="163"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="163" id="osg-1y-2sq"/>
-                                </constraints>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="dE9-4N-Kjw">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="MyCell" textLabel="bYJ-Ap-ihl" detailTextLabel="Ns3-DR-7jZ" style="IBUITableViewCellStyleSubtitle" id="dE9-4N-Kjw">
                                         <rect key="frame" x="0.0" y="28" width="568" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dE9-4N-Kjw" id="hpE-AD-psb">
                                             <rect key="frame" x="0.0" y="0.0" width="568" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bYJ-Ap-ihl">
+                                                    <rect key="frame" x="15" y="5" width="32" height="20"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ns3-DR-7jZ">
+                                                    <rect key="frame" x="15" y="25" width="41" height="14"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                                    <color key="textColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="highlightedColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="9uw-Zv-xGG" id="Hcf-yq-mVH"/>
+                                    <outlet property="delegate" destination="9uw-Zv-xGG" id="5Gh-5P-m2v"/>
+                                </connections>
                             </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Card Relation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p5E-N8-fBU">
+                                <rect key="frame" x="16" y="388" width="568" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="4Mb-zb-mjg" secondAttribute="trailing" id="8P8-rk-QPC"/>
-                            <constraint firstItem="r8B-uR-7hS" firstAttribute="top" secondItem="xKR-qC-ngB" secondAttribute="bottom" constant="8" symbolic="YES" id="AU6-wI-nBT"/>
-                            <constraint firstItem="xKR-qC-ngB" firstAttribute="top" secondItem="ou0-ID-tNs" secondAttribute="bottom" constant="8" symbolic="YES" id="Dzo-VA-4v4"/>
-                            <constraint firstAttribute="bottom" secondItem="ozq-M2-yuL" secondAttribute="bottom" constant="20" symbolic="YES" id="FB0-sn-ZSM"/>
-                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="top" secondItem="4CU-H5-0tI" secondAttribute="bottom" constant="8" symbolic="YES" id="GMP-5L-uNy"/>
-                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="top" secondItem="GxV-PX-DqU" secondAttribute="bottom" id="H2Q-6u-Ngj"/>
-                            <constraint firstItem="4CU-H5-0tI" firstAttribute="top" secondItem="4Mb-zb-mjg" secondAttribute="bottom" constant="23" id="H6M-uF-xYO"/>
-                            <constraint firstItem="ou0-ID-tNs" firstAttribute="trailing" secondItem="xKR-qC-ngB" secondAttribute="trailing" id="Lp3-I1-h3e"/>
-                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="leading" secondItem="ou0-ID-tNs" secondAttribute="leading" id="Ve9-KA-1JC"/>
-                            <constraint firstItem="r8B-uR-7hS" firstAttribute="trailing" secondItem="ozq-M2-yuL" secondAttribute="trailing" id="WNs-4r-rBn"/>
-                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="leading" secondItem="3s9-Bl-e48" secondAttribute="leading" id="afe-9P-f4J"/>
-                            <constraint firstItem="ozq-M2-yuL" firstAttribute="top" secondItem="r8B-uR-7hS" secondAttribute="bottom" constant="8" symbolic="YES" id="eF2-VG-Okn"/>
-                            <constraint firstItem="4CU-H5-0tI" firstAttribute="centerX" secondItem="cvx-Lc-TL9" secondAttribute="centerX" id="hdZ-Gk-TB0"/>
-                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="leading" secondItem="3s9-Bl-e48" secondAttribute="leadingMargin" constant="-4" id="mUo-Xc-Ytx"/>
-                            <constraint firstItem="xKR-qC-ngB" firstAttribute="trailing" secondItem="r8B-uR-7hS" secondAttribute="trailing" id="mfl-Fc-TVM"/>
-                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="centerX" secondItem="4CU-H5-0tI" secondAttribute="centerX" id="ntd-zx-k17"/>
-                            <constraint firstItem="ou0-ID-tNs" firstAttribute="top" secondItem="cvx-Lc-TL9" secondAttribute="bottom" constant="8" symbolic="YES" id="ozh-yF-qak"/>
-                            <constraint firstItem="xKR-qC-ngB" firstAttribute="leading" secondItem="r8B-uR-7hS" secondAttribute="leading" id="rEt-lC-Rwa"/>
-                            <constraint firstItem="r8B-uR-7hS" firstAttribute="leading" secondItem="ozq-M2-yuL" secondAttribute="leading" id="wg6-P5-hjj"/>
-                            <constraint firstItem="ou0-ID-tNs" firstAttribute="trailing" secondItem="cvx-Lc-TL9" secondAttribute="trailing" id="yKc-Rs-Nbk"/>
-                            <constraint firstItem="xKR-qC-ngB" firstAttribute="leading" secondItem="ou0-ID-tNs" secondAttribute="leading" id="zc2-yP-y84"/>
+                            <constraint firstItem="xKR-qC-ngB" firstAttribute="leading" secondItem="ou0-ID-tNs" secondAttribute="leading" id="3cc-Ki-zGT"/>
+                            <constraint firstItem="r8B-uR-7hS" firstAttribute="centerY" secondItem="3s9-Bl-e48" secondAttribute="centerY" id="3dM-tc-Fqz"/>
+                            <constraint firstAttribute="bottom" secondItem="ozq-M2-yuL" secondAttribute="bottom" constant="20" symbolic="YES" id="3nj-2B-d10"/>
+                            <constraint firstItem="p5E-N8-fBU" firstAttribute="leading" secondItem="r8B-uR-7hS" secondAttribute="leading" id="5kR-MY-y0v"/>
+                            <constraint firstItem="p5E-N8-fBU" firstAttribute="trailing" secondItem="ozq-M2-yuL" secondAttribute="trailing" id="7ZG-38-YNB"/>
+                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="top" secondItem="GxV-PX-DqU" secondAttribute="bottom" id="9fq-Y5-QNS"/>
+                            <constraint firstAttribute="trailing" secondItem="4Mb-zb-mjg" secondAttribute="trailing" id="C3C-PV-4py"/>
+                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="leading" secondItem="3s9-Bl-e48" secondAttribute="leading" id="Csx-d7-oHR"/>
+                            <constraint firstItem="4CU-H5-0tI" firstAttribute="top" secondItem="4Mb-zb-mjg" secondAttribute="bottom" constant="23" id="DZz-8U-CTC"/>
+                            <constraint firstItem="r8B-uR-7hS" firstAttribute="trailing" secondItem="p5E-N8-fBU" secondAttribute="trailing" id="J3r-ON-agX"/>
+                            <constraint firstItem="xKR-qC-ngB" firstAttribute="top" secondItem="ou0-ID-tNs" secondAttribute="bottom" constant="8" symbolic="YES" id="Mrp-NT-z7b"/>
+                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="trailing" secondItem="ou0-ID-tNs" secondAttribute="trailing" id="O84-Sf-S3F"/>
+                            <constraint firstItem="4CU-H5-0tI" firstAttribute="centerX" secondItem="4Mb-zb-mjg" secondAttribute="centerX" id="OQk-Lb-dN2"/>
+                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="leading" secondItem="ou0-ID-tNs" secondAttribute="leading" id="Ppz-IZ-Jv7"/>
+                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="centerX" secondItem="4CU-H5-0tI" secondAttribute="centerX" id="TFs-Aq-l2f"/>
+                            <constraint firstItem="ou0-ID-tNs" firstAttribute="top" secondItem="cvx-Lc-TL9" secondAttribute="bottom" constant="8" symbolic="YES" id="Y9Q-H0-Cn8"/>
+                            <constraint firstItem="ozq-M2-yuL" firstAttribute="leading" secondItem="p5E-N8-fBU" secondAttribute="leading" id="azD-aa-aLU"/>
+                            <constraint firstItem="ozq-M2-yuL" firstAttribute="top" secondItem="p5E-N8-fBU" secondAttribute="bottom" constant="8" symbolic="YES" id="cbG-Xh-KBS"/>
+                            <constraint firstItem="xKR-qC-ngB" firstAttribute="leading" secondItem="r8B-uR-7hS" secondAttribute="leading" id="dhW-1W-cJd"/>
+                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="top" secondItem="4CU-H5-0tI" secondAttribute="bottom" constant="8" symbolic="YES" id="ig1-Vh-zuH"/>
+                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="leading" secondItem="3s9-Bl-e48" secondAttribute="leadingMargin" constant="-4" id="il4-Ac-eBc"/>
+                            <constraint firstItem="r8B-uR-7hS" firstAttribute="top" secondItem="xKR-qC-ngB" secondAttribute="bottom" constant="8" symbolic="YES" id="qNq-vY-yhQ"/>
+                            <constraint firstItem="ou0-ID-tNs" firstAttribute="trailing" secondItem="xKR-qC-ngB" secondAttribute="trailing" id="u3s-wQ-f1x"/>
+                            <constraint firstItem="r8B-uR-7hS" firstAttribute="trailing" secondItem="xKR-qC-ngB" secondAttribute="trailing" id="xwd-Fs-dJ3"/>
+                            <constraint firstItem="p5E-N8-fBU" firstAttribute="top" secondItem="r8B-uR-7hS" secondAttribute="bottom" constant="8" symbolic="YES" id="zAg-A0-AM3"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Card" id="xMt-cZ-qUb">
@@ -244,6 +271,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="descriptionField" destination="r8B-uR-7hS" id="TWN-AM-qWp"/>
+                        <outlet property="relationCardTableView" destination="ozq-M2-yuL" id="5Ya-t9-Udm"/>
                         <outlet property="titleField" destination="ou0-ID-tNs" id="2e6-bz-lfH"/>
                         <outlet property="typeSegment" destination="4CU-H5-0tI" id="7fs-if-esC"/>
                     </connections>

--- a/KPTer/Base.lproj/Main.storyboard
+++ b/KPTer/Base.lproj/Main.storyboard
@@ -158,7 +158,7 @@
                                 </items>
                             </navigationBar>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r8B-uR-7hS" customClass="UIDescriptionTextView" customModule="KPTer" customModuleProvider="target">
-                                <rect key="frame" x="16" y="219" width="568" height="271"/>
+                                <rect key="frame" x="16" y="219" width="568" height="190"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -167,7 +167,7 @@
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="4CU-H5-0tI" userLabel="CardType">
                                 <rect key="frame" x="194" y="87" width="212" height="29"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="212" id="Wo3-V5-uFY"/>
+                                    <constraint firstAttribute="width" constant="212" id="BsP-HV-MsO"/>
                                 </constraints>
                                 <segments>
                                     <segment title="Keep"/>
@@ -187,27 +187,47 @@
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="ozq-M2-yuL">
+                                <rect key="frame" x="16" y="417" width="568" height="163"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="163" id="osg-1y-2sq"/>
+                                </constraints>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="dE9-4N-Kjw">
+                                        <rect key="frame" x="0.0" y="28" width="568" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dE9-4N-Kjw" id="hpE-AD-psb">
+                                            <rect key="frame" x="0.0" y="0.0" width="568" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="top" secondItem="GxV-PX-DqU" secondAttribute="bottom" id="1iY-xh-h5U"/>
-                            <constraint firstItem="8pj-zz-ZVE" firstAttribute="top" secondItem="r8B-uR-7hS" secondAttribute="bottom" constant="110" id="80J-kF-rzT"/>
-                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="trailing" secondItem="ou0-ID-tNs" secondAttribute="trailing" id="L6K-WE-3nT"/>
-                            <constraint firstItem="xKR-qC-ngB" firstAttribute="leading" secondItem="ou0-ID-tNs" secondAttribute="leading" id="Lwt-pP-Qdk"/>
-                            <constraint firstItem="r8B-uR-7hS" firstAttribute="trailing" secondItem="xKR-qC-ngB" secondAttribute="trailing" id="NeR-id-CsS"/>
-                            <constraint firstItem="xKR-qC-ngB" firstAttribute="trailing" secondItem="ou0-ID-tNs" secondAttribute="trailing" id="OUO-kd-VqM"/>
-                            <constraint firstAttribute="trailing" secondItem="4Mb-zb-mjg" secondAttribute="trailing" id="PAF-WD-ghr"/>
-                            <constraint firstItem="xKR-qC-ngB" firstAttribute="top" secondItem="ou0-ID-tNs" secondAttribute="bottom" constant="8" symbolic="YES" id="cSI-zS-lo3"/>
-                            <constraint firstItem="4CU-H5-0tI" firstAttribute="top" secondItem="4Mb-zb-mjg" secondAttribute="bottom" constant="23" id="dBv-Ti-UoG"/>
-                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="top" secondItem="4CU-H5-0tI" secondAttribute="bottom" constant="8" symbolic="YES" id="j7x-ci-2fO"/>
-                            <constraint firstItem="r8B-uR-7hS" firstAttribute="top" secondItem="xKR-qC-ngB" secondAttribute="bottom" constant="8" symbolic="YES" id="moj-7e-fC8"/>
-                            <constraint firstItem="ou0-ID-tNs" firstAttribute="leading" secondItem="cvx-Lc-TL9" secondAttribute="leading" id="qPQ-06-okh"/>
-                            <constraint firstItem="4CU-H5-0tI" firstAttribute="centerX" secondItem="cvx-Lc-TL9" secondAttribute="centerX" id="qVJ-FA-f58"/>
-                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="centerX" secondItem="4CU-H5-0tI" secondAttribute="centerX" id="tLt-eo-kcO"/>
-                            <constraint firstItem="xKR-qC-ngB" firstAttribute="leading" secondItem="r8B-uR-7hS" secondAttribute="leading" id="vG8-8K-MYo"/>
-                            <constraint firstItem="ou0-ID-tNs" firstAttribute="top" secondItem="cvx-Lc-TL9" secondAttribute="bottom" constant="8" symbolic="YES" id="vSb-9F-4WG"/>
-                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="leading" secondItem="3s9-Bl-e48" secondAttribute="leadingMargin" constant="-4" id="xAB-6F-gp5"/>
-                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="leading" secondItem="3s9-Bl-e48" secondAttribute="leading" id="zB6-ce-SAm"/>
+                            <constraint firstAttribute="trailing" secondItem="4Mb-zb-mjg" secondAttribute="trailing" id="8P8-rk-QPC"/>
+                            <constraint firstItem="r8B-uR-7hS" firstAttribute="top" secondItem="xKR-qC-ngB" secondAttribute="bottom" constant="8" symbolic="YES" id="AU6-wI-nBT"/>
+                            <constraint firstItem="xKR-qC-ngB" firstAttribute="top" secondItem="ou0-ID-tNs" secondAttribute="bottom" constant="8" symbolic="YES" id="Dzo-VA-4v4"/>
+                            <constraint firstAttribute="bottom" secondItem="ozq-M2-yuL" secondAttribute="bottom" constant="20" symbolic="YES" id="FB0-sn-ZSM"/>
+                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="top" secondItem="4CU-H5-0tI" secondAttribute="bottom" constant="8" symbolic="YES" id="GMP-5L-uNy"/>
+                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="top" secondItem="GxV-PX-DqU" secondAttribute="bottom" id="H2Q-6u-Ngj"/>
+                            <constraint firstItem="4CU-H5-0tI" firstAttribute="top" secondItem="4Mb-zb-mjg" secondAttribute="bottom" constant="23" id="H6M-uF-xYO"/>
+                            <constraint firstItem="ou0-ID-tNs" firstAttribute="trailing" secondItem="xKR-qC-ngB" secondAttribute="trailing" id="Lp3-I1-h3e"/>
+                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="leading" secondItem="ou0-ID-tNs" secondAttribute="leading" id="Ve9-KA-1JC"/>
+                            <constraint firstItem="r8B-uR-7hS" firstAttribute="trailing" secondItem="ozq-M2-yuL" secondAttribute="trailing" id="WNs-4r-rBn"/>
+                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="leading" secondItem="3s9-Bl-e48" secondAttribute="leading" id="afe-9P-f4J"/>
+                            <constraint firstItem="ozq-M2-yuL" firstAttribute="top" secondItem="r8B-uR-7hS" secondAttribute="bottom" constant="8" symbolic="YES" id="eF2-VG-Okn"/>
+                            <constraint firstItem="4CU-H5-0tI" firstAttribute="centerX" secondItem="cvx-Lc-TL9" secondAttribute="centerX" id="hdZ-Gk-TB0"/>
+                            <constraint firstItem="cvx-Lc-TL9" firstAttribute="leading" secondItem="3s9-Bl-e48" secondAttribute="leadingMargin" constant="-4" id="mUo-Xc-Ytx"/>
+                            <constraint firstItem="xKR-qC-ngB" firstAttribute="trailing" secondItem="r8B-uR-7hS" secondAttribute="trailing" id="mfl-Fc-TVM"/>
+                            <constraint firstItem="4Mb-zb-mjg" firstAttribute="centerX" secondItem="4CU-H5-0tI" secondAttribute="centerX" id="ntd-zx-k17"/>
+                            <constraint firstItem="ou0-ID-tNs" firstAttribute="top" secondItem="cvx-Lc-TL9" secondAttribute="bottom" constant="8" symbolic="YES" id="ozh-yF-qak"/>
+                            <constraint firstItem="xKR-qC-ngB" firstAttribute="leading" secondItem="r8B-uR-7hS" secondAttribute="leading" id="rEt-lC-Rwa"/>
+                            <constraint firstItem="r8B-uR-7hS" firstAttribute="leading" secondItem="ozq-M2-yuL" secondAttribute="leading" id="wg6-P5-hjj"/>
+                            <constraint firstItem="ou0-ID-tNs" firstAttribute="trailing" secondItem="cvx-Lc-TL9" secondAttribute="trailing" id="yKc-Rs-Nbk"/>
+                            <constraint firstItem="xKR-qC-ngB" firstAttribute="leading" secondItem="ou0-ID-tNs" secondAttribute="leading" id="zc2-yP-y84"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Card" id="xMt-cZ-qUb">

--- a/KPTer/BoardEditViewController.swift
+++ b/KPTer/BoardEditViewController.swift
@@ -33,9 +33,9 @@ class BoardEditViewController: UIViewController {
     }
     
     @IBAction func save(sender: AnyObject) {
-        if (self.identifier == Identifiers.FromAddButtonToBoardEdit.rawValue) {
+        if (Identifiers.isBoardAdd(self.identifier)) {
             BoardViewModel.create(self.boardTitleField.text!)
-        } else if (self.identifier == Identifiers.FromEditButtonToBoardEdit.rawValue) {
+        } else if (Identifiers.isBoardEdit(self.identifier)) {
             let editBoard = Board()
             editBoard.board_title = self.boardTitleField.text!
             BoardViewModel.edit(board!, editBoard: editBoard)            

--- a/KPTer/BoardEditViewController.swift
+++ b/KPTer/BoardEditViewController.swift
@@ -33,9 +33,9 @@ class BoardEditViewController: UIViewController {
     }
     
     @IBAction func save(sender: AnyObject) {
-        if (self.identifier == Identifiers.BoardAdd.rawValue) {
+        if (self.identifier == Identifiers.FromAddButtonToBoardEdit.rawValue) {
             BoardViewModel.create(self.boardTitleField.text!)
-        } else if (self.identifier == Identifiers.BoardEdit.rawValue) {
+        } else if (self.identifier == Identifiers.FromEditButtonToBoardEdit.rawValue) {
             let editBoard = Board()
             editBoard.board_title = self.boardTitleField.text!
             BoardViewModel.edit(board!, editBoard: editBoard)            

--- a/KPTer/BoardListViewController.swift
+++ b/KPTer/BoardListViewController.swift
@@ -117,7 +117,7 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
         } else if (segue.identifier == Identifiers.FromAddButtonToBoardEdit.rawValue) {
             // 追加ボタンから遷移したことを示す識別子をボード画面に渡す
             let boardEditViewController = (segue.destinationViewController as? BoardEditViewController)
-            boardEditViewController?.identifier = Identifiers.BoardAdd.rawValue
+            boardEditViewController?.identifier = Identifiers.FromAddButtonToBoardEdit.rawValue
             self.needRefresh = true
         }
     }
@@ -140,7 +140,7 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
             // ボードエンティティを渡す
             boardEditViewController.board = board
             // Editボタンから遷移したことを示す識別子をボード画面に渡す
-            boardEditViewController.identifier = Identifiers.BoardEdit.rawValue
+            boardEditViewController.identifier = Identifiers.FromEditButtonToBoardEdit.rawValue
             self.needRefresh = true
             // モーダル表示する
             boardEditViewController.modalTransitionStyle = UIModalTransitionStyle.CoverVertical

--- a/KPTer/BoardListViewController.swift
+++ b/KPTer/BoardListViewController.swift
@@ -103,18 +103,17 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
     }
     
     /*
-    KPTAreaに遷移する前処理
-    ここでKptAreaViewControllerにボード、カードを渡す
+    画面遷移する前処理
     */
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
 
-        if (segue.identifier == Identifiers.ToKptAreaViewController.rawValue) {
+        if (Identifiers.isToKptAreaViewController(segue.identifier!)) {
             // KptAreaのコントローラーにボードを渡す
             let kptAreaViewController = (segue.destinationViewController as? KptAreaViewController)
             let board = self.boardEntities![boardListTableView.indexPathForSelectedRow!.row]
             kptAreaViewController!.board = board
             self.needRefresh = false
-        } else if (segue.identifier == Identifiers.FromAddButtonToBoardEdit.rawValue) {
+        } else if (Identifiers.isBoardAdd(segue.identifier!)) {
             // 追加ボタンから遷移したことを示す識別子をボード画面に渡す
             let boardEditViewController = (segue.destinationViewController as? BoardEditViewController)
             boardEditViewController?.identifier = Identifiers.FromAddButtonToBoardEdit.rawValue

--- a/KPTer/BoardListViewController.swift
+++ b/KPTer/BoardListViewController.swift
@@ -20,6 +20,9 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
     // リフレッシュコントロール
     var refreshControl:UIRefreshControl!
     
+    // ボードリストのリフレッシュが必要かのフラグ
+    var needRefresh = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
@@ -107,15 +110,15 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
 
         if (segue.identifier == Identifiers.ToKptAreaViewController.rawValue) {
             // KptAreaのコントローラーにボードを渡す
-
             let kptAreaViewController = (segue.destinationViewController as? KptAreaViewController)
             let board = self.boardEntities![boardListTableView.indexPathForSelectedRow!.row]
             kptAreaViewController!.board = board
-            
+            self.needRefresh = false
         } else if (segue.identifier == Identifiers.FromAddButtonToBoardEdit.rawValue) {
             // 追加ボタンから遷移したことを示す識別子をボード画面に渡す
             let boardEditViewController = (segue.destinationViewController as? BoardEditViewController)
             boardEditViewController?.identifier = Identifiers.BoardAdd.rawValue
+            self.needRefresh = true
         }
     }
     
@@ -138,6 +141,7 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
             boardEditViewController.board = board
             // Editボタンから遷移したことを示す識別子をボード画面に渡す
             boardEditViewController.identifier = Identifiers.BoardEdit.rawValue
+            self.needRefresh = true
             // モーダル表示する
             boardEditViewController.modalTransitionStyle = UIModalTransitionStyle.CoverVertical
             self.presentViewController(boardEditViewController, animated: true, completion: nil)
@@ -172,9 +176,16 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
      ボードリスト画面が表示されるごとに、ボードエンティティを取得して再描画する
     */
     override func viewWillAppear(animated: Bool) {
-        boardEntities = BoardViewModel.findBoards(BoardViewModel.SortKey.CreatedAt, ascDesc: BoardViewModel.AscDesc.Desc)
-        boardListTableView.reloadData()
         super.viewWillAppear(animated)
+        
+        if let indexPathForSelectedRow = boardListTableView.indexPathForSelectedRow {
+            boardListTableView.deselectRowAtIndexPath(indexPathForSelectedRow, animated: true)
+        }
+
+        if (self.needRefresh) {
+            boardEntities = BoardViewModel.findBoards(BoardViewModel.SortKey.CreatedAt, ascDesc: BoardViewModel.AscDesc.Desc)
+            boardListTableView.reloadData()
+        }
     }
 }
 

--- a/KPTer/BoardListViewController.swift
+++ b/KPTer/BoardListViewController.swift
@@ -20,6 +20,9 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
     // リフレッシュコントロール
     var refreshControl:UIRefreshControl!
     
+    // ボードリストのリフレッシュが必要かのフラグ
+    var needRefresh = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
@@ -107,15 +110,15 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
 
         if (segue.identifier == Identifiers.ToKptAreaViewController.rawValue) {
             // KptAreaのコントローラーにボードを渡す
-
             let kptAreaViewController = (segue.destinationViewController as? KptAreaViewController)
             let board = self.boardEntities![boardListTableView.indexPathForSelectedRow!.row]
             kptAreaViewController!.board = board
-            
+            self.needRefresh = false
         } else if (segue.identifier == Identifiers.FromAddButtonToBoardEdit.rawValue) {
             // 追加ボタンから遷移したことを示す識別子をボード画面に渡す
             let boardEditViewController = (segue.destinationViewController as? BoardEditViewController)
             boardEditViewController?.identifier = Identifiers.BoardAdd.rawValue
+            self.needRefresh = true
         }
     }
     
@@ -138,6 +141,7 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
             boardEditViewController.board = board
             // Editボタンから遷移したことを示す識別子をボード画面に渡す
             boardEditViewController.identifier = Identifiers.BoardEdit.rawValue
+            self.needRefresh = true
             // モーダル表示する
             boardEditViewController.modalTransitionStyle = UIModalTransitionStyle.CoverVertical
             self.presentViewController(boardEditViewController, animated: true, completion: nil)
@@ -185,9 +189,16 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
      ボードリスト画面が表示されるごとに、ボードエンティティを取得して再描画する
     */
     override func viewWillAppear(animated: Bool) {
-        boardEntities = BoardViewModel.findBoards(BoardViewModel.SortKey.CreatedAt, ascDesc: BoardViewModel.AscDesc.Desc)
-        boardListTableView.reloadData()
         super.viewWillAppear(animated)
+        
+        if let indexPathForSelectedRow = boardListTableView.indexPathForSelectedRow {
+            boardListTableView.deselectRowAtIndexPath(indexPathForSelectedRow, animated: true)
+        }
+
+        if (self.needRefresh) {
+            boardEntities = BoardViewModel.findBoards(BoardViewModel.SortKey.CreatedAt, ascDesc: BoardViewModel.AscDesc.Desc)
+            boardListTableView.reloadData()
+        }
     }
 }
 

--- a/KPTer/BoardListViewController.swift
+++ b/KPTer/BoardListViewController.swift
@@ -148,16 +148,29 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
         
         // Deleteボタン
         let deleteButton: UITableViewRowAction = UITableViewRowAction(style: .Normal , title: "Delete") { (action, index) -> Void in
-            tableView.editing = false
-            // ボードを削除する
-            BoardViewModel.delete(self.boardEntities![indexPath.row])
-            self.viewWillAppear(true)
+            // 削除確認アラートを表示する
+            let alertController = UIAlertController(title: "Caution!", message: "Are you sure that you are deleting '\(self.boardEntities![index.row].board_title)'.", preferredStyle: .Alert)
             
+            // OKボタン押下時
+            let defaultAction = UIAlertAction(title: "OK", style: .Default) {
+                action in BoardViewModel.delete(self.boardEntities![indexPath.row])
+                self.viewWillAppear(true)
+            }
+            
+            // CANCELボタン押下時
+            let cancelAction = UIAlertAction(title: "CANCEL", style: .Cancel) {
+                action in tableView.editing = false
+            }
+            
+            alertController.addAction(defaultAction)
+            alertController.addAction(cancelAction)
+            self.presentViewController(alertController, animated: true, completion: nil)
         }
         deleteButton.backgroundColor = UIColor.redColor()
         
         return [deleteButton, editButton]
     }
+    
     
     /**
      テーブルを下に引っ張ってリロードする

--- a/KPTer/BoardListViewController.swift
+++ b/KPTer/BoardListViewController.swift
@@ -123,7 +123,7 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
     }
     
     /*
-    Butonを拡張する
+    Buttonを拡張する
     */
     func tableView(tableView: UITableView, editActionsForRowAtIndexPath indexPath: NSIndexPath) -> [UITableViewRowAction]? {
         
@@ -158,6 +158,7 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
             // OKボタン押下時
             let defaultAction = UIAlertAction(title: "OK", style: .Default) {
                 action in BoardViewModel.delete(self.boardEntities![indexPath.row])
+                self.needRefresh = true
                 self.viewWillAppear(true)
             }
             
@@ -174,7 +175,6 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
         
         return [deleteButton, editButton]
     }
-    
     
     /**
      テーブルを下に引っ張ってリロードする

--- a/KPTer/Card.swift
+++ b/KPTer/Card.swift
@@ -34,4 +34,16 @@ class Card: Object {
     override static func primaryKey() -> String? {
         return "id"
     }
+    
+    func isKeep() -> Bool{
+        return self.type == CardType.Keep.rawValue
+    }
+    
+    func isProblem() -> Bool{
+        return self.type == CardType.Problem.rawValue
+    }
+    
+    func isTry() -> Bool{
+        return self.type == CardType.Try.rawValue
+    }
 }

--- a/KPTer/CardViewController.swift
+++ b/KPTer/CardViewController.swift
@@ -237,9 +237,9 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
     */
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         // 選択されたCardを保持しておく
-        if (self.isKeepSection(indexPath)) {
+        if (self.isKeepSection(indexPath.section)) {
             selectedRelationCard = keepCardEntities[indexPath.row]
-        } else if(self.isProblemSection(indexPath)) {
+        } else if(self.isProblemSection(indexPath.section)) {
             selectedRelationCard = problemCardEntities[indexPath.row]
         }
         // チェックをつける
@@ -260,9 +260,9 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
     テーブルに表示する配列の総数を返す.
     */
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if (section == CardTypeSectionIndex.Keep.rawValue) {
+        if (self.isKeepSection(section)) {
             return keepCardEntities.count
-        } else if (section == CardTypeSectionIndex.Problem.rawValue) {
+        } else if (self.isProblemSection(section)) {
             return problemCardEntities.count
         } else {
             return 0
@@ -276,7 +276,7 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
         
         let cell = tableView.dequeueReusableCellWithIdentifier("MyCell", forIndexPath: indexPath)
         
-        if (self.isKeepSection(indexPath)) {
+        if (self.isKeepSection(indexPath.section)) {
             // Keepカードセクションの場合、Keepカードエンティティのタイトル、詳細をセルに設定する
             cell.textLabel!.text = keepCardEntities[indexPath.row].card_title
             cell.detailTextLabel!.text = keepCardEntities[indexPath.row].detail
@@ -289,7 +289,7 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
                 }
             }
             
-        } else if (self.isProblemSection(indexPath)) {
+        } else if (self.isProblemSection(indexPath.section)) {
             // Problemカードセクションの場合、Problemカードエンティティのタイトル、詳細をセルに設定する
             cell.textLabel!.text = problemCardEntities[indexPath.row].card_title
             cell.detailTextLabel!.text = problemCardEntities[indexPath.row].detail
@@ -334,19 +334,19 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     /**
      リレーションカード選択テーブルの中のKeepカードセクションかどうか
-     - parameter nsIndex: インデックスパス
+     - parameter section: セクション番号
      - returns: true YES、false No
      */
-    private func isKeepSection(nsIndex: NSIndexPath) -> Bool {
-        return nsIndex.section == CardTypeSectionIndex.Keep.rawValue
+    private func isKeepSection(section: Int) -> Bool {
+        return section == CardTypeSectionIndex.Keep.rawValue
     }
     
     /**
      リレーションカード選択テーブルの中のProblemカードセクションかどうか
-     - parameter nsIndex: インデックスパス
+     - parameter section: セクション番号
      - returns: true YES、false No
      */
-    private func isProblemSection(nsIndex: NSIndexPath) -> Bool {
-        return nsIndex.section == CardTypeSectionIndex.Problem.rawValue
+    private func isProblemSection(section: Int) -> Bool {
+        return section == CardTypeSectionIndex.Problem.rawValue
     }
 }

--- a/KPTer/CardViewController.swift
+++ b/KPTer/CardViewController.swift
@@ -133,9 +133,6 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
             editCard.detail = self.descriptionField.text
             editCard.type = self.getCardTypeFromSegmentIndex(self.typeSegment.selectedSegmentIndex).rawValue
             CardViewModel.edit(self.card!, editCard: editCard)
-            
-            // cellを特定する
-            
         }
         self.dismissViewControllerAnimated(true, completion: nil)
     }

--- a/KPTer/CardViewController.swift
+++ b/KPTer/CardViewController.swift
@@ -25,6 +25,10 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
     // 画面遷移の識別子(ボード一覧のAddから来たかEditからきたか判別)
     var identifier: String = ""
     
+    @IBOutlet weak var cardTypeSegumentedControl: UISegmentedControl!
+    
+    @IBOutlet weak var cardRelationLabel: UILabel!
+    
     enum CardTypeSegmentIndex: Int {
         case Keep = 0
         case Problem = 1
@@ -45,10 +49,16 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
             typeSegment.selectedSegmentIndex = self.getSegmentIndexFromCardType(cardEntity)
             titleField.text = cardEntity.card_title
             descriptionField.text = cardEntity.detail
+            if (CardTypeSegmentIndex.Keep.rawValue == self.getSegmentIndexFromCardType(cardEntity)
+                || CardTypeSegmentIndex.Problem.rawValue == self.getSegmentIndexFromCardType(cardEntity)) {
+                relationCardTableView.hidden = true
+                cardRelationLabel.hidden = true
+            }
         }
         keepCardEntities = BoardViewModel.findKeepCard(self.board)
         problemCardEntities = BoardViewModel.findKeepCard(self.board)
-
+        
+        cardTypeSegumentedControl.addTarget(self, action: "segmentedControlChanged:", forControlEvents: UIControlEvents.ValueChanged)
         // カードエンティティが渡ってこない場合は何もしない
     }
 
@@ -147,8 +157,12 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
             // relationテーブルにカードを表示する
             keepCardEntities = BoardViewModel.findKeepCard(self.board)
             problemCardEntities = BoardViewModel.findKeepCard(self.board)
+            relationCardTableView.hidden = false
+            cardRelationLabel.hidden = false
         } else {
-            // TODO: relationテーブルを非表示（または非活性）にする
+            // relationテーブルを非表示（または非活性）にする
+            relationCardTableView.hidden = true
+            cardRelationLabel.hidden = true
         }
     }
 

--- a/KPTer/CardViewController.swift
+++ b/KPTer/CardViewController.swift
@@ -79,7 +79,6 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
             // カードタイプがKeep, Problemの場合、リレーションテーブルを非表示にする
             if (self.card!.isKeep()
                 || self.card!.isProblem()) {
-
                 relationCardTableView.hidden = true
                 cardRelationLabel.hidden = true
             }
@@ -130,7 +129,6 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
                     presentViewController(alertController, animated: true, completion: nil)
 
                     return
-
                 }
             }
             
@@ -244,7 +242,6 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
         // チェックをつける
         let cell = tableView.cellForRowAtIndexPath(indexPath)
         cell!.accessoryType = UITableViewCellAccessoryType.Checkmark
-
     }
     
     /*
@@ -277,9 +274,11 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
         let cell = tableView.dequeueReusableCellWithIdentifier("MyCell", forIndexPath: indexPath)
         
         if (indexPath.section == CardTypeSectionIndex.Keep.rawValue) {
+            // Keepカードセクションの場合、Keepカードエンティティのタイトル、詳細をセルに設定する
             cell.textLabel!.text = keepCardEntities[indexPath.row].card_title
             cell.detailTextLabel!.text = keepCardEntities[indexPath.row].detail
             
+            // 紐付けたカードのセルにチェックマークをつける
             if let relationCard = self.selectedRelationCard {
                 if (relationCard.id == keepCardEntities[indexPath.row].id) {
                     // チェックをつける
@@ -288,10 +287,11 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
             }
             
         } else if (indexPath.section == CardTypeSectionIndex.Problem.rawValue) {
+            // Problemカードセクションの場合、Problemカードエンティティのタイトル、詳細をセルに設定する
             cell.textLabel!.text = problemCardEntities[indexPath.row].card_title
             cell.detailTextLabel!.text = problemCardEntities[indexPath.row].detail
-
             
+            // 紐付けたカードのセルにチェックマークをつける
             if let relationCard = self.selectedRelationCard {
                 if (relationCard.id == problemCardEntities[indexPath.row].id) {
                     // チェックをつける
@@ -299,7 +299,6 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
                 }
             }
         }
-        
         return cell
     }
     

--- a/KPTer/CardViewController.swift
+++ b/KPTer/CardViewController.swift
@@ -62,7 +62,7 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
         keepCardEntities = BoardViewModel.findKeepCard(self.board)
         problemCardEntities = BoardViewModel.findProblemCard(self.board)
         
-        if let cardEntity = self.card {
+        if (self.identifier == Identifiers.FromEditButtonToCardEdit.rawValue) {
             // カードエンティティが渡ってきたら（編集時のみ）
             // FIXME: card typeは、KPTエリアで追加ボタン押下時に選択させるUIにする。
             // それまでは、変更できないように非活性にする
@@ -71,26 +71,28 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
             }
             
             // card情報を画面に設定
-            typeSegment.selectedSegmentIndex = self.getSegmentIndexFromCardType(cardEntity)
-            titleField.text = cardEntity.card_title
-            descriptionField.text = cardEntity.detail
+            typeSegment.selectedSegmentIndex = self.getSegmentIndexFromCardType(self.card!)
+            titleField.text = self.card!.card_title
+            descriptionField.text = self.card!.detail
             
             // カードタイプがKeep, Problemの場合、リレーションテーブルを非表示にする
-            if (cardEntity.type == Card.CardType.Keep.rawValue
-                || cardEntity.type == Card.CardType.Problem.rawValue) {
+            if (self.card!.isKeep()
+                || self.card!.isProblem()) {
                 relationCardTableView.hidden = true
                 cardRelationLabel.hidden = true
             }
             
             // カードタイプがTryの場合、リレーションカードに値を設定する
-            if (cardEntity.type == Card.CardType.Try.rawValue) {
-                self.selectedRelationCard = CardViewModel.findCardRelation(cardEntity)
+            if (self.card!.isTry()) {
+                self.selectedRelationCard = CardViewModel.findCardRelation(self.card!)
             }
             
-        } else {
+        } else if (self.identifier == Identifiers.FromAddButtonToCardEdit.rawValue) {
             // 新規作成の場合、relationカードは非表示
             relationCardTableView.hidden = true
             cardRelationLabel.hidden = true
+        } else {
+            // FIXME: 例外処理したい
         }
         
         // CardTypeのセグメントのイベントを設定する
@@ -123,6 +125,8 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
                     let defaultAction = UIAlertAction(title: "OK", style: .Default, handler: nil)
                     alertController.addAction(defaultAction)
                     presentViewController(alertController, animated: true, completion: nil)
+                    
+                    return
                 }
             }
             
@@ -235,7 +239,7 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
         // チェックをつける
         let cell = tableView.cellForRowAtIndexPath(indexPath)
-        cell?.accessoryType = UITableViewCellAccessoryType.Checkmark
+        cell!.accessoryType = UITableViewCellAccessoryType.Checkmark
     }
     
     /*
@@ -268,8 +272,8 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
         let cell = tableView.dequeueReusableCellWithIdentifier("MyCell", forIndexPath: indexPath)
         
         if indexPath.section == CardTypeSectionIndex.Keep.rawValue {
-            cell.textLabel?.text = "\(keepCardEntities[indexPath.row].card_title)"
-            cell.detailTextLabel!.text = "\(keepCardEntities[indexPath.row].detail)"
+            cell.textLabel!.text = keepCardEntities[indexPath.row].card_title
+            cell.detailTextLabel!.text = keepCardEntities[indexPath.row].detail
             
             if let relationCard = self.selectedRelationCard {
                 if (relationCard.id == keepCardEntities[indexPath.row].id) {
@@ -279,8 +283,8 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
             }
             
         } else if indexPath.section == CardTypeSectionIndex.Problem.rawValue {
-            cell.textLabel?.text = "\(problemCardEntities[indexPath.row].card_title)"
-            cell.detailTextLabel!.text = "\(problemCardEntities[indexPath.row].detail)"
+            cell.textLabel!.text = problemCardEntities[indexPath.row].card_title
+            cell.detailTextLabel!.text = problemCardEntities[indexPath.row].detail
             
             if let relationCard = self.selectedRelationCard {
                 if (relationCard.id == problemCardEntities[indexPath.row].id) {

--- a/KPTer/CardViewController.swift
+++ b/KPTer/CardViewController.swift
@@ -9,15 +9,17 @@
 import UIKit
 import RealmSwift
 
-class CardViewController: UIViewController {
+class CardViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
     @IBOutlet weak var typeSegment: UISegmentedControl!
     // card title field
     @IBOutlet weak var titleField: UITextField!
     // description field
     @IBOutlet weak var descriptionField: UITextView!
+    // relation card table view
+    @IBOutlet weak var relationCardTableView: UITableView!
     // KPTエリアから受け取るボード
-    var board: Board? = nil
+    var board: Board! = nil
     // KPTエリアから受け取るカード
     var card: Card? = nil
     // 画面遷移の識別子(ボード一覧のAddから来たかEditからきたか判別)
@@ -29,6 +31,12 @@ class CardViewController: UIViewController {
         case Try = 2
     }
     
+    let relationCardTableSections = [Card.CardType.Keep.rawValue, Card.CardType.Problem.rawValue]
+    
+    var keepCardEntities: Results<Card>!
+    
+    var problemCardEntities: Results<Card>!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view
@@ -38,7 +46,9 @@ class CardViewController: UIViewController {
             titleField.text = cardEntity.card_title
             descriptionField.text = cardEntity.detail
         }
-        
+        keepCardEntities = BoardViewModel.findKeepCard(self.board)
+        problemCardEntities = BoardViewModel.findKeepCard(self.board)
+
         // カードエンティティが渡ってこない場合は何もしない
     }
 
@@ -128,5 +138,70 @@ class CardViewController: UIViewController {
             return Card.CardType.Keep
         }
     }
+    
+    /*
+    segmentが切り替わったときに呼ばれるイベント
+    */
+    func segmentedControlChanged(sender: UISegmentedControl) {
+        if (sender.selectedSegmentIndex == CardTypeSegmentIndex.Try.rawValue) {
+            // relationテーブルにカードを表示する
+            keepCardEntities = BoardViewModel.findKeepCard(self.board)
+            problemCardEntities = BoardViewModel.findKeepCard(self.board)
+        } else {
+            // TODO: relationテーブルを非表示（または非活性）にする
+        }
+    }
 
+    /*
+    セクションの数を返す.
+    */
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        // Keep, Problem, Tryテーブルそれぞれ1セクション固定
+        return relationCardTableSections.count
+    }
+    
+    /*
+    セクションのタイトルを返す.
+    */
+    func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return relationCardTableSections[section]
+    }
+    
+    /*
+    Cellが選択された際に呼び出される.
+    */
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        // TODO: チェックがつけばいいな
+    }
+    
+    /*
+    テーブルに表示する配列の総数を返す.
+    */
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == 0 {
+            return keepCardEntities.count
+        } else if section == 1 {
+            return problemCardEntities.count
+        } else {
+            return 0
+        }
+    }
+    
+    /*
+    Cellに値を設定する.
+    */
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        
+        let cell = tableView.dequeueReusableCellWithIdentifier("MyCell", forIndexPath: indexPath)
+        
+        if indexPath.section == 0 {
+            cell.textLabel?.text = "\(keepCardEntities[indexPath.row].card_title)"
+            cell.detailTextLabel!.text = "\(keepCardEntities[indexPath.row].detail)"
+        } else if indexPath.section == 1 {
+            cell.textLabel?.text = "\(problemCardEntities[indexPath.row].card_title)"
+            cell.detailTextLabel!.text = "\(problemCardEntities[indexPath.row].detail)"
+        }
+        
+        return cell
+    }
 }

--- a/KPTer/CardViewController.swift
+++ b/KPTer/CardViewController.swift
@@ -10,14 +10,21 @@ import UIKit
 import RealmSwift
 
 class CardViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-
+    // 画面内オブジェクト
+    // card typeセグメント
     @IBOutlet weak var typeSegment: UISegmentedControl!
-    // card title field
+    // card titleフィールド
     @IBOutlet weak var titleField: UITextField!
-    // description field
+    // descriptionフィールド
     @IBOutlet weak var descriptionField: UITextView!
     // relation card table view
     @IBOutlet weak var relationCardTableView: UITableView!
+    // cart typeセグメントコントローラー
+    @IBOutlet weak var cardTypeSegumentedControl: UISegmentedControl!
+    // relation card ラベル
+    @IBOutlet weak var cardRelationLabel: UILabel!
+    
+    // KPTエリアから受け取るパラメーター
     // KPTエリアから受け取るボード
     var board: Board! = nil
     // KPTエリアから受け取るカード
@@ -25,41 +32,69 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
     // 画面遷移の識別子(ボード一覧のAddから来たかEditからきたか判別)
     var identifier: String = ""
     
-    @IBOutlet weak var cardTypeSegumentedControl: UISegmentedControl!
-    
-    @IBOutlet weak var cardRelationLabel: UILabel!
-    
+    // 内部利用変数
+    // リレーション選択テーブルのセクション（Keep, Problem）
+    let relationCardTableSections = [Card.CardType.Keep.rawValue, Card.CardType.Problem.rawValue]
+    // リレーション選択テーブルに表示するKeepカードリスト
+    var keepCardEntities: Results<Card>!
+    // リレーション選択テーブルに表示するProblemカードリスト
+    var problemCardEntities: Results<Card>!
+    // リレーション選択テーブルで選択されたカード
+    var selectedRelationCard: Card? = nil
+    // セグメントに割り当てたカードタイプの値
     enum CardTypeSegmentIndex: Int {
         case Keep = 0
         case Problem = 1
         case Try = 2
     }
-    
-    let relationCardTableSections = [Card.CardType.Keep.rawValue, Card.CardType.Problem.rawValue]
-    
-    var keepCardEntities: Results<Card>!
-    
-    var problemCardEntities: Results<Card>!
+    // relation cardセクション
+    enum CardTypeSectionIndex: Int {
+        case Keep = 0
+        case Problem = 1
+        // Tryはリレーションで使わないので不要
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view
-        // カードエンティティが渡ってきたら（基本、編集時のみ）
-        if let cardEntity = card {
+        
+        // relationテーブルにKeep, Problemカードを設定する
+        keepCardEntities = BoardViewModel.findKeepCard(self.board)
+        problemCardEntities = BoardViewModel.findProblemCard(self.board)
+        
+        if let cardEntity = self.card {
+            // カードエンティティが渡ってきたら（編集時のみ）
+            // FIXME: card typeは、KPTエリアで追加ボタン押下時に選択させるUIにする。
+            // それまでは、変更できないように非活性にする
+            for (var i = 0; i < typeSegment.numberOfSegments; i++) {
+                typeSegment.setEnabled(false, forSegmentAtIndex: i)
+            }
+            
+            // card情報を画面に設定
             typeSegment.selectedSegmentIndex = self.getSegmentIndexFromCardType(cardEntity)
             titleField.text = cardEntity.card_title
             descriptionField.text = cardEntity.detail
-            if (CardTypeSegmentIndex.Keep.rawValue == self.getSegmentIndexFromCardType(cardEntity)
-                || CardTypeSegmentIndex.Problem.rawValue == self.getSegmentIndexFromCardType(cardEntity)) {
+            
+            // カードタイプがKeep, Problemの場合、リレーションテーブルを非表示にする
+            if (cardEntity.type == Card.CardType.Keep.rawValue
+                || cardEntity.type == Card.CardType.Problem.rawValue) {
                 relationCardTableView.hidden = true
                 cardRelationLabel.hidden = true
             }
+            
+            // カードタイプがTryの場合、リレーションカードに値を設定する
+            if (cardEntity.type == Card.CardType.Try.rawValue) {
+                self.selectedRelationCard = CardViewModel.findCardRelation(cardEntity)
+            }
+            
+        } else {
+            // 新規作成の場合、relationカードは非表示
+            relationCardTableView.hidden = true
+            cardRelationLabel.hidden = true
         }
-        keepCardEntities = BoardViewModel.findKeepCard(self.board)
-        problemCardEntities = BoardViewModel.findKeepCard(self.board)
         
+        // CardTypeのセグメントのイベントを設定する
         cardTypeSegumentedControl.addTarget(self, action: "segmentedControlChanged:", forControlEvents: UIControlEvents.ValueChanged)
-        // カードエンティティが渡ってこない場合は何もしない
     }
 
     override func didReceiveMemoryWarning() {
@@ -79,9 +114,16 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
             } else if (self.typeSegment.selectedSegmentIndex == CardTypeSegmentIndex.Problem.rawValue) {
                 BoardViewModel.addProblemCard(self.board!, title: self.titleField.text!, detail: self.descriptionField.text)
             } else if (self.typeSegment.selectedSegmentIndex == CardTypeSegmentIndex.Try.rawValue) {
-                // FIXME: Tryカードの紐付け元を設定する
-                //BoardViewModel.addTryCard(<#T##board: Board##Board#>, title: <#T##String#>, detail: <#T##String#>, fromCard: <#T##Card#>)
-                print("add try card!!")
+                // Tryカードの紐付け元を設定する
+                if let relationCard = self.selectedRelationCard {
+                    BoardViewModel.addTryCard(self.board, title: self.titleField.text!, detail: self.descriptionField.text, fromCard: relationCard)
+                } else {
+                    // リレーションカードが選択されていない場合、エラーポップアップ表示
+                    let alertController = UIAlertController(title: "Not selected relation card.", message: "Please select a relation card on relation table.", preferredStyle: .Alert)
+                    let defaultAction = UIAlertAction(title: "OK", style: .Default, handler: nil)
+                    alertController.addAction(defaultAction)
+                    presentViewController(alertController, animated: true, completion: nil)
+                }
             }
             
         } else if (self.identifier == Identifiers.FromEditButtonToCardEdit.rawValue) {
@@ -91,6 +133,9 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
             editCard.detail = self.descriptionField.text
             editCard.type = self.getCardTypeFromSegmentIndex(self.typeSegment.selectedSegmentIndex).rawValue
             CardViewModel.edit(self.card!, editCard: editCard)
+            
+            // cellを特定する
+            
         }
         self.dismissViewControllerAnimated(true, completion: nil)
     }
@@ -156,7 +201,7 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
         if (sender.selectedSegmentIndex == CardTypeSegmentIndex.Try.rawValue) {
             // relationテーブルにカードを表示する
             keepCardEntities = BoardViewModel.findKeepCard(self.board)
-            problemCardEntities = BoardViewModel.findKeepCard(self.board)
+            problemCardEntities = BoardViewModel.findProblemCard(self.board)
             relationCardTableView.hidden = false
             cardRelationLabel.hidden = false
         } else {
@@ -185,16 +230,33 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
     Cellが選択された際に呼び出される.
     */
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        // TODO: チェックがつけばいいな
+        // 選択されたCardを保持しておく
+        if (indexPath.section == CardTypeSectionIndex.Keep.rawValue) {
+            selectedRelationCard = keepCardEntities[indexPath.row]
+        } else if(indexPath.section == CardTypeSectionIndex.Problem.rawValue) {
+            selectedRelationCard = problemCardEntities[indexPath.row]
+        }
+        // チェックをつける
+        let cell = tableView.cellForRowAtIndexPath(indexPath)
+        cell?.accessoryType = UITableViewCellAccessoryType.Checkmark
+    }
+    
+    /*
+    Cellの選択が外れた時に呼び出される
+    */
+    func tableView(tableView: UITableView, didDeselectRowAtIndexPath indexPath: NSIndexPath) {
+        // チェックを外す
+        let cell = tableView.cellForRowAtIndexPath(indexPath)
+        cell!.accessoryType = UITableViewCellAccessoryType.None
     }
     
     /*
     テーブルに表示する配列の総数を返す.
     */
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if section == 0 {
+        if section == CardTypeSectionIndex.Keep.rawValue {
             return keepCardEntities.count
-        } else if section == 1 {
+        } else if section == CardTypeSectionIndex.Problem.rawValue {
             return problemCardEntities.count
         } else {
             return 0
@@ -208,14 +270,30 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
         
         let cell = tableView.dequeueReusableCellWithIdentifier("MyCell", forIndexPath: indexPath)
         
-        if indexPath.section == 0 {
+        if indexPath.section == CardTypeSectionIndex.Keep.rawValue {
             cell.textLabel?.text = "\(keepCardEntities[indexPath.row].card_title)"
             cell.detailTextLabel!.text = "\(keepCardEntities[indexPath.row].detail)"
-        } else if indexPath.section == 1 {
+            
+            if let relationCard = self.selectedRelationCard {
+                if (relationCard.id == keepCardEntities[indexPath.row].id) {
+                    // チェックをつける
+                    cell.accessoryType = UITableViewCellAccessoryType.Checkmark
+                }
+            }
+            
+        } else if indexPath.section == CardTypeSectionIndex.Problem.rawValue {
             cell.textLabel?.text = "\(problemCardEntities[indexPath.row].card_title)"
             cell.detailTextLabel!.text = "\(problemCardEntities[indexPath.row].detail)"
+            
+            if let relationCard = self.selectedRelationCard {
+                if (relationCard.id == problemCardEntities[indexPath.row].id) {
+                    // チェックをつける
+                    cell.accessoryType = UITableViewCellAccessoryType.Checkmark
+                }
+            }
         }
         
         return cell
     }
+    
 }

--- a/KPTer/Identifiers.swift
+++ b/KPTer/Identifiers.swift
@@ -23,5 +23,4 @@ public enum Identifiers:String {
     case FromAddButtonToCardEdit = "fromAddButtonToCardEdit"
     // カード編集ボタンからカード編集画面へ遷移したことを示す識別子
     case FromEditButtonToCardEdit = "fromEditButtonToCardEdit"
-    
 }

--- a/KPTer/Identifiers.swift
+++ b/KPTer/Identifiers.swift
@@ -7,19 +7,63 @@
 //
 
 import Foundation
-import UIKit
 
 public enum Identifiers:String {
     // ボード追加ボタンからボード編集画面へ遷移したことを示す識別子
     case FromAddButtonToBoardEdit = "fromAddButtonToBoardEdit"
-    // ボード追加ボタンからボード編集画面へ遷移したことを示す識別子
+    // ボード編集ボタンからボード編集画面へ遷移したことを示す識別子
     case FromEditButtonToBoardEdit = "fromEditButtonToBoardEdit"
-    // ボード選択→KPTエリア画面遷移
-    case ToKptAreaViewController = "toKptAreaViewController"
-    // KPTエリア画面遷移→カード画面遷移
-    case ToCardViewController = "toCardViewController"
     // カード追加ボタンからカード編集画面へ遷移したことを示す識別子
     case FromAddButtonToCardEdit = "fromAddButtonToCardEdit"
     // カード編集(セル選択)からカード編集画面へ遷移したことを示す識別子
     case FromEditButtonToCardEdit = "fromEditButtonToCardEdit"
+    
+    // KPTエリア画面遷移
+    case ToKptAreaViewController = "toKptAreaViewController"
+
+    /**
+     ボード追加アクションとして遷移したか
+     - parameter identifer: 画面遷移識別子
+     - returns: true した、false していない
+     */
+    static func isBoardAdd(identifer: String) -> Bool {
+        return identifer == self.FromAddButtonToBoardEdit.rawValue ? true : false
+    }
+    
+    /**
+     ボード編集アクションとして遷移したか
+     - parameter identifer: 画面遷移識別子
+     - returns: true した、false していない
+     */
+    static func isBoardEdit(identifer: String) -> Bool {
+        return identifer == self.FromEditButtonToBoardEdit.rawValue ? true : false
+    }
+    
+    /**
+     カード追加アクションとして遷移したか
+     - parameter identifer: 画面遷移識別子
+     - returns: true した、false していない
+     */
+    static func isCardAdd(identifer: String) -> Bool {
+        return identifer == self.FromAddButtonToCardEdit.rawValue ? true : false
+    }
+    
+    /**
+     カード編集アクションとして遷移したか
+     - parameter identifer: 画面遷移識別子
+     - returns: true した、false していない
+     */
+    static func isCardEdit(identifer: String) -> Bool {
+        return identifer == self.FromEditButtonToCardEdit.rawValue ? true : false
+    }
+    
+    /**
+     KPTエリアへの遷移アクションか
+     - parameter identifer: 画面遷移識別子
+     - returns: true した、false していない
+     */
+    static func isToKptAreaViewController(identifer: String) -> Bool {
+        return identifer == self.ToKptAreaViewController.rawValue ? true : false
+    }
 }
+

--- a/KPTer/Identifiers.swift
+++ b/KPTer/Identifiers.swift
@@ -7,20 +7,19 @@
 //
 
 import Foundation
+import UIKit
 
 public enum Identifiers:String {
-    // ボード追加ボタン
-    case BoardAdd = "add"
-    // ボード編集ボタン
-    case BoardEdit = "edit"
     // ボード追加ボタンからボード編集画面へ遷移したことを示す識別子
     case FromAddButtonToBoardEdit = "fromAddButtonToBoardEdit"
+    // ボード追加ボタンからボード編集画面へ遷移したことを示す識別子
+    case FromEditButtonToBoardEdit = "fromEditButtonToBoardEdit"
     // ボード選択→KPTエリア画面遷移
     case ToKptAreaViewController = "toKptAreaViewController"
     // KPTエリア画面遷移→カード画面遷移
     case ToCardViewController = "toCardViewController"
     // カード追加ボタンからカード編集画面へ遷移したことを示す識別子
     case FromAddButtonToCardEdit = "fromAddButtonToCardEdit"
-    // カード編集ボタンからカード編集画面へ遷移したことを示す識別子
+    // カード編集(セル選択)からカード編集画面へ遷移したことを示す識別子
     case FromEditButtonToCardEdit = "fromEditButtonToCardEdit"
 }

--- a/KPTer/KptAreaViewController.swift
+++ b/KPTer/KptAreaViewController.swift
@@ -64,22 +64,22 @@ class KptAreaViewController: UIViewController, UITableViewDelegate, UITableViewD
     セクションのタイトルを返す.
     */
     func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        if tableView.tag == TableViewTags.KeepTableViewTag.rawValue {
+        if (TableViewTags.isKeepTableView(tableView)) {
             return Card.CardType.Keep.rawValue
-        } else if tableView.tag == TableViewTags.ProblemTableViewTag.rawValue {
+        } else if (TableViewTags.isProblemTableView(tableView)) {
             return Card.CardType.Problem.rawValue
-        } else if tableView.tag == TableViewTags.TryTableViewTag.rawValue {
+        } else if (TableViewTags.isTryTableView(tableView)) {
             return Card.CardType.Try.rawValue
         }
         return "Illegal Card Type!!"
     }
     
     func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if tableView.tag == TableViewTags.KeepTableViewTag.rawValue {
+        if (TableViewTags.isKeepTableView(tableView)) {
             return keepCardEntities.count
-        } else if tableView.tag == TableViewTags.ProblemTableViewTag.rawValue {
+        } else if (TableViewTags.isProblemTableView(tableView)) {
             return problemCardEntities.count
-        } else if tableView.tag == TableViewTags.TryTableViewTag.rawValue {
+        } else if (TableViewTags.isTryTableView(tableView)) {
             return tryCardEntities.count
         }
         return 0
@@ -89,19 +89,19 @@ class KptAreaViewController: UIViewController, UITableViewDelegate, UITableViewD
         
         let cell:UITableViewCell? = nil
         
-        if tableView.tag == TableViewTags.KeepTableViewTag.rawValue {
+        if (TableViewTags.isKeepTableView(tableView)) {
             let keepCell:KeepCardTableViewCell = tableView.dequeueReusableCellWithIdentifier("KeepCard") as! KeepCardTableViewCell
             keepCell.setCell(keepCardEntities[indexPath.row])
             
             return keepCell
             
-        } else if tableView.tag == TableViewTags.ProblemTableViewTag.rawValue {
+        } else if (TableViewTags.isProblemTableView(tableView)) {
             let problemCell:ProblemCardTableViewCell = tableView.dequeueReusableCellWithIdentifier("ProblemCard") as! ProblemCardTableViewCell
             problemCell.setCell(problemCardEntities[indexPath.row])
             
             return problemCell
             
-        } else if tableView.tag == TableViewTags.TryTableViewTag.rawValue {
+        } else if (TableViewTags.isTryTableView(tableView)) {
             let tryCell:TryCardTableViewCell = tableView.dequeueReusableCellWithIdentifier("TryCard") as! TryCardTableViewCell
             tryCell.setCell(tryCardEntities[indexPath.row])
             
@@ -119,12 +119,12 @@ class KptAreaViewController: UIViewController, UITableViewDelegate, UITableViewD
         // CardViewControllerに必要情報を渡す
         let cardViewController = segue.destinationViewController as! CardViewController
 
-        if (segue.identifier == Identifiers.FromAddButtonToCardEdit.rawValue) {
+        if (Identifiers.isCardAdd(segue.identifier!)) {
             // 追加ボタンの処理
             // 追加ボタンから遷移したことを示す識別子をカード画面に渡す
             cardViewController.identifier = segue.identifier!
             
-        } else if (segue.identifier == Identifiers.FromEditButtonToCardEdit.rawValue) {
+        } else if (Identifiers.isCardEdit(segue.identifier!)) {
             // セル選択時の処理
             // カードとセル選択されたことを示す識別子をカード画面に渡す
             let cardTableViewCell = sender as! CardTableViewCell

--- a/KPTer/KptAreaViewController.swift
+++ b/KPTer/KptAreaViewController.swift
@@ -169,22 +169,4 @@ class KptAreaViewController: UIViewController, UITableViewDelegate, UITableViewD
         self.tryTableView.reloadData()
         
     }
-    
-    // experiment: 実験データ
-    private func experimentData() {
-        BoardViewModel.addKeepCard(self.board!, title: "白いちご行けた", detail: "次は白いちごを狩りいく")
-        BoardViewModel.addKeepCard(self.board!, title: "ブランケットから飴ちゃん出てきた(*ﾉ´∀`*)ﾉ", detail: "おいしい")
-        BoardViewModel.addKeepCard(self.board!, title: "KPTer開発に動き出せた", detail: "誰かがよろこんでくれたら嬉しい")
-        BoardViewModel.addProblemCard(self.board!, title: "休日のごはん事情", detail: "餓死しちゃう")
-        BoardViewModel.addProblemCard(self.board!, title: "【悲報】エクセルは私達だけのものではなかった・・・！", detail: "エクセル利用者がすぐそこにいた")
-        
-        self.keepCardEntities = BoardViewModel.findKeepCard(board!)
-        self.problemCardEntities = BoardViewModel.findProblemCard(board!)
-        
-        
-        BoardViewModel.addTryCard(self.board!, title: "休日のごはん事情", detail: "はやく起きて、朝・昼ちゃんと食べる", fromCard: self.problemCardEntities[0])
-        BoardViewModel.addTryCard(self.board!, title: "エクセル", detail: "鉢合わせても仕方ないくらいのノリか？", fromCard: self.problemCardEntities[1])
-        
-        self.tryCardEntities = BoardViewModel.findTryCard(board!)
-    }
 }

--- a/KPTer/TableViewTags.swift
+++ b/KPTer/TableViewTags.swift
@@ -7,9 +7,37 @@
 //
 
 import Foundation
+import UIKit
 
 public enum TableViewTags: Int {
     case KeepTableViewTag = 0
     case ProblemTableViewTag = 1
     case TryTableViewTag = 2
+    
+    /**
+     Keepカードテーブルビューか
+     - parameter tableView: テーブルビュー
+     - returns: true YES、false NO
+     */
+    static func isKeepTableView(tableView: UITableView) -> Bool {
+        return tableView.tag == TableViewTags.KeepTableViewTag.rawValue ? true : false
+    }
+    
+    /**
+     Problemカードテーブルビューか
+     - parameter tableView: テーブルビュー
+     - returns: true YES、false NO
+     */
+    static func isProblemTableView(tableView: UITableView) -> Bool {
+        return tableView.tag == TableViewTags.ProblemTableViewTag.rawValue ? true : false
+    }
+    
+    /**
+     Tryカードテーブルビューか
+     - parameter tableView: テーブルビュー
+     - returns: true YES、false NO
+     */
+    static func isTryTableView(tableView: UITableView) -> Bool {
+        return tableView.tag == TableViewTags.TryTableViewTag.rawValue ? true : false
+    }
 }

--- a/KPTerTests/CardSpec.swift
+++ b/KPTerTests/CardSpec.swift
@@ -17,6 +17,13 @@ class CardSpec: QuickSpec {
         BoardViewModel.addTryCard(newBoard!, title: "new card title2", detail: "new card detail2", fromCard: newCard!)
         BoardViewModel.addProblemCard(newBoard!, title: "new card title2", detail: "new card detail2")
         
+        
+        describe("Keepカードの場合、trueを返却する") {
+            it("Keepカードの場合、trueを返却すること") {
+                expect(newCard!.isKeep()).to(equal(true))
+            }
+        }
+        
         describe("Cardの関連元を取得する") {
             it("Tryに紐づくKeepCardが取得できること") {
                 expect(CardViewModel.findCardRelation(BoardViewModel.findTryCard(newBoard!).first!).id).to(equal(newCard!.id))


### PR DESCRIPTION
Fixes #81 .

Changes proposed in this pull request:
- Tryカードの追加機能実装
- カード追加時にカードタイプを選択できるUIを追加（暫定）。将来的にはカード追加画面からカードタイプは消し、カード新規追加時にカードタイプを選んでからカード画面に遷移する。 #91 で対応したい。
- Tryカード追加時に、リレーションカードを設定できるように設定
- Tryカード追加時に、リレーションが未選択の場合はアラート画面表示（bugあり #95）

こんなイメージでTryカード追加（最後バグった）
![kpter-image- 81](https://cloud.githubusercontent.com/assets/16001636/14587291/d2e1032a-04eb-11e6-996b-3077ea76d7d3.gif)

@HanaLucky/KPTer
