### PR TITLE
カード種別を判定するメソッドを作成

### DIFF
--- a/KPTer/Card.swift
+++ b/KPTer/Card.swift
@@ -34,4 +34,16 @@ class Card: Object {
     override static func primaryKey() -> String? {
         return "id"
     }
+    
+    func isKeep() -> Bool{
+        return self.type == CardType.Keep.rawValue
+    }
+    
+    func isProblem() -> Bool{
+        return self.type == CardType.Problem.rawValue
+    }
+    
+    func isTry() -> Bool{
+        return self.type == CardType.Try.rawValue
+    }
 }

--- a/KPTerTests/CardSpec.swift
+++ b/KPTerTests/CardSpec.swift
@@ -17,6 +17,13 @@ class CardSpec: QuickSpec {
         BoardViewModel.addTryCard(newBoard!, title: "new card title2", detail: "new card detail2", fromCard: newCard!)
         BoardViewModel.addProblemCard(newBoard!, title: "new card title2", detail: "new card detail2")
         
+        
+        describe("Keepカードの場合、trueを返却する") {
+            it("Keepカードの場合、trueを返却すること") {
+                expect(newCard!.isKeep()).to(equal(true))
+            }
+        }
+        
         describe("Cardの関連元を取得する") {
             it("Tryに紐づくKeepCardが取得できること") {
                 expect(CardViewModel.findCardRelation(BoardViewModel.findTryCard(newBoard!).first!).id).to(equal(newCard!.id))


### PR DESCRIPTION
Fixes #97.

Changes proposed in this pull request:
-  カード種別を判定するメソッドを作成

@HanaLucky/KPTer
