### PR TITLE
ボード一覧画面のテーブル幅をstoryboard上で変更可能にする

### DIFF
--- a/KPTer/Base.lproj/Main.storyboard
+++ b/KPTer/Base.lproj/Main.storyboard
@@ -18,30 +18,34 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="40" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="4aL-dA-g9g">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="40" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="4aL-dA-g9g">
+                                <rect key="frame" x="20" y="0.0" width="560" height="556"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="BoardListItem" rowHeight="40" id="9AA-MD-NOF" customClass="BoardListItemTableViewCell" customModule="KPTer" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="92" width="600" height="40"/>
+                                        <rect key="frame" x="0.0" y="92" width="560" height="40"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9AA-MD-NOF" id="UWz-hk-CIb">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="39"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="560" height="39"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="Y5D-lk-Nlk" kind="show" identifier="toKptAreaViewController" id="2HL-WP-XQD"/>
+                                            <segue destination="Y5D-lk-Nlk" kind="show" identifier="toKptAreaViewController" id="gjd-bc-KLY"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="BYZ-38-t0r" id="J9s-ab-Q13"/>
+                                    <outlet property="delegate" destination="BYZ-38-t0r" id="4GC-f6-mVx"/>
+                                </connections>
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="4aL-dA-g9g" firstAttribute="bottom" secondItem="wfy-db-euE" secondAttribute="top" id="D7T-LW-rCA"/>
-                            <constraint firstItem="4aL-dA-g9g" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="KDt-CS-fBC"/>
-                            <constraint firstItem="4aL-dA-g9g" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="e48-84-j9r"/>
-                            <constraint firstAttribute="trailing" secondItem="4aL-dA-g9g" secondAttribute="trailing" id="yXm-FL-qSU"/>
+                            <constraint firstItem="4aL-dA-g9g" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="DTT-Sx-NzZ"/>
+                            <constraint firstItem="4aL-dA-g9g" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="DbA-JU-eI7"/>
+                            <constraint firstItem="4aL-dA-g9g" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="GDD-bn-pFC"/>
+                            <constraint firstItem="4aL-dA-g9g" firstAttribute="bottom" secondItem="wfy-db-euE" secondAttribute="top" id="ZRs-Iy-ld2"/>
                         </constraints>
                     </view>
                     <toolbarItems>
@@ -54,6 +58,9 @@
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="Tcv-FR-mVF"/>
                     </toolbarItems>
                     <navigationItem key="navigationItem" title="Board List" id="kcH-AW-P1P"/>
+                    <connections>
+                        <outlet property="boardListTableView" destination="4aL-dA-g9g" id="uXJ-oh-civ"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/KPTer/BoardListViewController.swift
+++ b/KPTer/BoardListViewController.swift
@@ -16,8 +16,7 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
     var boardEntities: Results<Board>?
     
     // テーブルビュー
-    private var boardListTableView: UITableView!
-    
+    @IBOutlet weak var boardListTableView: UITableView!
     // リフレッシュコントロール
     var refreshControl:UIRefreshControl!
     
@@ -28,32 +27,6 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         boardEntities = BoardViewModel.findBoards(BoardViewModel.SortKey.CreatedAt, ascDesc: BoardViewModel.AscDesc.Desc)
-        
-        // reference https://sites.google.com/a/gclue.jp/swift-docs/ni-yinki100-ios/uikit/006-uitableviewdeteburuwo-biao-shi
-        // Status Barの高さを取得する.
-        let barHeight: CGFloat = UIApplication.sharedApplication().statusBarFrame.size.height
-        
-        // Navigation Barの高さを取得する
-        let navigationBarHeight = self.navigationController?.navigationBar.frame.height
-        
-        
-        // Viewの高さと幅を取得する.
-        let displayWidth: CGFloat = self.view.frame.width
-        let displayHeight: CGFloat = self.view.frame.height
-        
-        // TableViewの生成する(status bar, navigation barの高さ分ずらして表示).
-        boardListTableView = UITableView(frame: CGRect(x: 0, y: barHeight + navigationBarHeight!, width: displayWidth, height: displayHeight - barHeight - navigationBarHeight!))
-        
-        // Cell名の登録をおこなう.
-        boardListTableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: "MyCell")
-        
-        // DataSourceの設定をする.
-        boardListTableView.dataSource = self
-        
-        // Delegateを設定する.
-        boardListTableView.delegate = self
-        
-        boardListTableView.separatorColor = .clearColor()
         
         // 引っ張ってリロードする
         refreshControl = UIRefreshControl()
@@ -85,7 +58,7 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
         
         // 再利用するCellを取得する.
         
-        let cell = tableView.dequeueReusableCellWithIdentifier("MyCell", forIndexPath: indexPath)
+        let cell = tableView.dequeueReusableCellWithIdentifier("BoardListItem", forIndexPath: indexPath)
         
         // cellに対し、UIFlatKit適応
         let corners = UIRectCorner.AllCorners
@@ -106,13 +79,6 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
         if editingStyle == .Delete {
             tableView.reloadData()
         }
-    }
-    
-    /*
-    Cellが選択された際に呼び出される.
-    */
-    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        performSegueWithIdentifier(Identifiers.ToKptAreaViewController.rawValue, sender: nil)
     }
     
     /*

--- a/KPTer/BoardListViewController.swift
+++ b/KPTer/BoardListViewController.swift
@@ -136,8 +136,7 @@ class BoardListViewController: UIViewController, UITableViewDelegate, UITableVie
             // OKボタン押下時
             let defaultAction = UIAlertAction(title: "OK", style: .Default) {
                 action in BoardViewModel.delete(self.boardEntities![indexPath.row])
-                self.needRefresh = true
-                self.viewWillAppear(true)
+                tableView.deleteRowsAtIndexPaths([NSIndexPath(forRow: indexPath.row, inSection: 0)],withRowAnimation: UITableViewRowAnimation.Fade)
             }
             
             // CANCELボタン押下時


### PR DESCRIPTION
Fixes #126 .

Changes proposed in this pull request:
-  ボード一覧画面のテーブル幅をstoryboard上で変更可能にした（以下イメージ）

![2016-05-01 18 15 36](https://cloud.githubusercontent.com/assets/16001636/14941042/21601a44-0fc9-11e6-83bf-ff670312c63f.png)

@HanaLucky/KPTer
