### PR TITLE
紐付き先のTryカードを複数もつK,Pカードを削除したとき、複数のTryカードを削除する

### DIFF
--- a/KPTer/CardViewModel.swift
+++ b/KPTer/CardViewModel.swift
@@ -83,6 +83,20 @@ class CardViewModel {
     }
     
     /**
+     カードの関連を複数削除します。
+     - parameter tryCard: ひも付け元カード
+     */
+    class func deleteCardRelations(tryCards: Array<Card>) {
+        let realm = try! Realm()
+        for tryCard in tryCards {
+            let cardRelations = realm.objects(CardRelation).filter("to_id = '\(tryCard.id)'")
+            try! realm.write {
+                realm.delete(cardRelations)
+            }
+        }
+    }
+    
+    /**
      カードの紐付き元を取得します。
      - parameter tryCard: ひも付け先カード
      */
@@ -98,14 +112,18 @@ class CardViewModel {
      紐付き先が存在しない場合はnilを返却する。
      - parameter card: ひも付け元カード
      */
-    class func findFromCardRelation(card: Card) -> Card? {
+    class func findFromCardRelations(card: Card) -> Array<Card>? {
         let realm = try! Realm()
         let cardRelations: Results! = realm.objects(CardRelation).filter("from_id = '\(card.id)'")
         if (cardRelations.isEmpty) {
             return nil
         }
-        let card = realm.objects(Card).filter("id = '\(cardRelations!.first!.to_id)'").first
-        return card!
+        var cards: Array = [Card]()
+        for cardRelation in cardRelations {
+            let card = realm.objects(Card).filter("id = '\(cardRelation.to_id)'").first
+            cards.append(card!)
+        }
+        return cards
     }
     
     /**

--- a/KPTer/KptAreaViewController.swift
+++ b/KPTer/KptAreaViewController.swift
@@ -328,7 +328,7 @@ class KptAreaViewController: UIViewController, UITableViewDelegate, UITableViewD
         if (targetCard.isKeep() || targetCard.isProblem()) {
             // Keep, Problemカードの場合、リレーションが存在するか確認。確認後リレーション先のTryカードも同時に削除する
             
-            if let tryCard:Card = CardViewModel.findFromCardRelation(targetCard) {
+            if let tryCards:Array<Card> = CardViewModel.findFromCardRelations(targetCard) {
                 // 紐付け先のTryカードが存在する場合、警告ポップアップを表示する
                 // 削除確認アラートを表示する
                 let alertController = UIAlertController(title: "Caution!", message: "Related Try card will be deleted. Are you sure you want to delete this card?", preferredStyle: .Alert)
@@ -336,8 +336,10 @@ class KptAreaViewController: UIViewController, UITableViewDelegate, UITableViewD
                 // OKボタン押下時
                 let defaultAction = UIAlertAction(title: "OK", style: .Default) {
                     // OKの場合、紐付け先のTryカード、リレーション、Keepカードを削除する。
-                    action in CardViewModel.deleteCardRelation(tryCard)
-                    CardViewModel.delete(tryCard)
+                    action in CardViewModel.deleteCardRelations(tryCards)
+                    for tryCard in tryCards {
+                        CardViewModel.delete(tryCard)
+                    }
                     CardViewModel.delete(targetCard)
                 
                     // それからテーブルビューの更新


### PR DESCRIPTION
Fixes #127 .

Changes proposed in this pull request:
①

> class func findFromCardRelation(card: Card) -> Card?
- 上記メソッドの名前を-Relationsに変更
- 上記の戻り値をArray<Card>に変更

②

> class func deleteCardRelation(tryCard: Card)
- 上記メソッドの名前を-Relationsに変更
- 引数をArray<Card>に変更

@HanaLucky/KPTer
