### PR TITLE
Feature/issue154 hide keyboard retry

### DIFF
--- a/KPTer/Base.lproj/Main.storyboard
+++ b/KPTer/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="14F1713" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="DZw-oe-8C8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1808" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="DZw-oe-8C8">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -26,7 +26,7 @@
                                         <rect key="frame" x="0.0" y="92" width="560" height="40"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9AA-MD-NOF" id="UWz-hk-CIb">
-                                            <rect key="frame" x="0.0" y="0.0" width="560" height="39.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="560" height="39"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                         <connections>
@@ -107,6 +107,7 @@
                             </textField>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="1uH-iy-AKP" firstAttribute="centerX" secondItem="ncD-Vh-bxX" secondAttribute="centerX" id="AQ4-mc-Wmc"/>
                             <constraint firstItem="ncD-Vh-bxX" firstAttribute="top" secondItem="CIt-dg-WY0" secondAttribute="bottom" id="a9q-b5-2cO"/>
@@ -114,6 +115,9 @@
                             <constraint firstAttribute="trailing" secondItem="ncD-Vh-bxX" secondAttribute="trailing" id="oah-fs-cUy"/>
                             <constraint firstItem="ncD-Vh-bxX" firstAttribute="leading" secondItem="dHO-8U-Bla" secondAttribute="leading" id="wQi-Aj-bJ4"/>
                         </constraints>
+                        <connections>
+                            <outletCollection property="gestureRecognizers" destination="gmn-EK-8Mk" appends="YES" id="Y31-cM-HqF"/>
+                        </connections>
                     </view>
                     <navigationItem key="navigationItem" id="ooQ-5p-Jco">
                         <barButtonItem key="rightBarButtonItem" systemItem="save" id="PJW-u2-XDd"/>
@@ -124,6 +128,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tza-V0-mvS" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="gmn-EK-8Mk">
+                    <connections>
+                        <action selector="tapScreen:" destination="8cP-mE-d4G" id="wyR-CU-nfb"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="2159" y="295"/>
         </scene>
@@ -166,7 +175,7 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r8B-uR-7hS" customClass="UIDescriptionTextView" customModule="KPTer" customModuleProvider="target">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r8B-uR-7hS" customClass="UIDescriptionTextView" customModule="KPTer" customModuleProvider="target">
                                 <rect key="frame" x="16" y="219" width="568" height="161"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -204,18 +213,18 @@
                                         <rect key="frame" x="0.0" y="28" width="568" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dE9-4N-Kjw" id="hpE-AD-psb">
-                                            <rect key="frame" x="0.0" y="0.0" width="568" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="568" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bYJ-Ap-ihl">
-                                                    <rect key="frame" x="15" y="6" width="31.5" height="19.5"/>
+                                                    <rect key="frame" x="15" y="5" width="32" height="20"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ns3-DR-7jZ">
-                                                    <rect key="frame" x="15" y="25.5" width="40.5" height="13.5"/>
+                                                    <rect key="frame" x="15" y="25" width="41" height="14"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <color key="textColor" name="secondarySelectedControlColor" catalog="System" colorSpace="catalog"/>
@@ -230,7 +239,7 @@
                                     <outlet property="delegate" destination="9uw-Zv-xGG" id="5Gh-5P-m2v"/>
                                 </connections>
                             </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Card Relation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p5E-N8-fBU">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Card Relation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p5E-N8-fBU">
                                 <rect key="frame" x="16" y="388" width="568" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -238,6 +247,7 @@
                             </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="xKR-qC-ngB" firstAttribute="leading" secondItem="ou0-ID-tNs" secondAttribute="leading" id="3cc-Ki-zGT"/>
                             <constraint firstItem="r8B-uR-7hS" firstAttribute="centerY" secondItem="3s9-Bl-e48" secondAttribute="centerY" id="3dM-tc-Fqz"/>
@@ -265,6 +275,9 @@
                             <constraint firstItem="r8B-uR-7hS" firstAttribute="trailing" secondItem="xKR-qC-ngB" secondAttribute="trailing" id="xwd-Fs-dJ3"/>
                             <constraint firstItem="p5E-N8-fBU" firstAttribute="top" secondItem="r8B-uR-7hS" secondAttribute="bottom" constant="8" symbolic="YES" id="zAg-A0-AM3"/>
                         </constraints>
+                        <connections>
+                            <outletCollection property="gestureRecognizers" destination="kAm-UH-PT4" appends="YES" id="acR-LQ-H2l"/>
+                        </connections>
                     </view>
                     <navigationItem key="navigationItem" title="Card" id="xMt-cZ-qUb">
                         <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="fRd-6k-J7L">
@@ -289,6 +302,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8d4-zF-twJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="kAm-UH-PT4">
+                    <connections>
+                        <action selector="tapScreen:" destination="9uw-Zv-xGG" id="633-nw-F5k"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="2159" y="1055"/>
         </scene>
@@ -352,18 +370,18 @@
                                                                 <rect key="frame" x="0.0" y="28" width="520" height="44"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="711-kK-ET8" id="f0E-z5-IHw">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="520" height="43.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="520" height="43"/>
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                     <subviews>
                                                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="0hV-HJ-F6f">
-                                                                            <rect key="frame" x="15" y="6" width="31.5" height="19.5"/>
+                                                                            <rect key="frame" x="15" y="5" width="32" height="20"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="CUy-m5-zbA">
-                                                                            <rect key="frame" x="15" y="25.5" width="40.5" height="13.5"/>
+                                                                            <rect key="frame" x="15" y="25" width="41" height="14"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                                             <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
@@ -389,18 +407,18 @@
                                                                 <rect key="frame" x="0.0" y="28" width="520" height="44"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="z5m-dc-TvE" id="ZpK-Yc-X6R">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="520" height="43.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="520" height="43"/>
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                     <subviews>
                                                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="vKH-a9-BUc">
-                                                                            <rect key="frame" x="15" y="6" width="31.5" height="19.5"/>
+                                                                            <rect key="frame" x="15" y="5" width="32" height="20"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Rt4-oQ-5wM">
-                                                                            <rect key="frame" x="15" y="25.5" width="40.5" height="13.5"/>
+                                                                            <rect key="frame" x="15" y="25" width="41" height="14"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
@@ -452,7 +470,7 @@
                                                                 <rect key="frame" x="0.0" y="28" width="520" height="44"/>
                                                                 <autoresizingMask key="autoresizingMask"/>
                                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="S2m-JW-jbG" id="hvo-Th-e88">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="520" height="43.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="520" height="43"/>
                                                                     <autoresizingMask key="autoresizingMask"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jer-fB-ocK">

--- a/KPTer/Base.lproj/Main.storyboard
+++ b/KPTer/Base.lproj/Main.storyboard
@@ -95,7 +95,7 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" placeholder="New Board Name" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1uH-iy-AKP" userLabel="Board Title Field" customClass="FUITextField">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" placeholder="Board Name" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1uH-iy-AKP" userLabel="Board Title Field" customClass="FUITextField">
                                 <rect key="frame" x="171" y="138" width="258" height="58"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="58" id="aYx-Rb-zZC"/>
@@ -148,7 +148,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="card title" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ou0-ID-tNs" customClass="FUITextField">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Card Title" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ou0-ID-tNs" customClass="FUITextField">
                                 <rect key="frame" x="16" y="152" width="568" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>

--- a/KPTer/BoardEditViewController.swift
+++ b/KPTer/BoardEditViewController.swift
@@ -82,7 +82,7 @@ class BoardEditViewController: UIViewController, UITextFieldDelegate {
     @IBAction func cancel(sender: AnyObject) {
         self.dismissViewControllerAnimated(true, completion: nil)
     }
-    
+
     /**
      タップイベント
      画面外をタップされた時に、編集モードを完了させる（keyboardが表示されなくなる）
@@ -91,6 +91,7 @@ class BoardEditViewController: UIViewController, UITextFieldDelegate {
     @IBAction func tapScreen(sender: UITapGestureRecognizer) {
         self.view.endEditing(true)
     }
+
     /*
     // MARK: - Navigation
 

--- a/KPTer/CardViewController.swift
+++ b/KPTer/CardViewController.swift
@@ -369,8 +369,16 @@ class CardViewController: UIViewController, UITableViewDelegate, UITableViewData
      - parameter sender: ジェスチャー
      */
     @IBAction func tapScreen(sender: UITapGestureRecognizer) {
+        // 編集モードを終了させる（キーボードを下ろすことで、リレーションテーブルが隠れないようにする）
         self.view.endEditing(true)
+        
+        // タップジェスチャーを設定するとテーブル選択できなくなるので、このイベントの中でテーブル選択イベントを呼ぶ
+        let touch = sender.locationInView(self.relationCardTableView)
+        if let indexPath = self.relationCardTableView.indexPathForRowAtPoint(touch) {
+            self.tableView(self.relationCardTableView, willSelectRowAtIndexPath: indexPath)
+        }
     }
+    
     /**
      カードタイプにKeepが選択されているか
      - parameter segment: セグメントコントロール

--- a/KPTer/KptAreaViewController.swift
+++ b/KPTer/KptAreaViewController.swift
@@ -99,8 +99,8 @@ class KptAreaViewController: UIViewController, UITableViewDelegate, UITableViewD
         for (var i:NSInteger = 0; i < tryTableView.numberOfRowsInSection(0); i++) {
             let cell:TryCardTableViewCell = tryTableView.cellForRowAtIndexPath(NSIndexPath(forRow: i, inSection: 0)) as! TryCardTableViewCell
             cell.status.hidden = true
-            cell.textLabel!.frame.origin.x = cell.status.frame.origin.x
-            cell.detailTextLabel!.frame.origin.x = cell.status.frame.origin.x
+            cell.title!.frame.origin.x = cell.status.frame.origin.x
+            cell.detail!.frame.origin.x = cell.status.frame.origin.x
         }
         
         // 編集ボタンのタイトルをdoneにし、アクションにdoneメソッドを指定する


### PR DESCRIPTION
Fixes #154 .

Changes proposed in this pull request:
- カード画面、ボード画面で、画面外タップによりキーボードが非表示になるように対応
- カード編集画面でボード名が未入力の時のplaceholderの文言を「New Borad Name」から「Board Name」に変更（編集時にタイトルを全て消した場合にNew Board Nameは違和感があるため）
- KPTエリアでEditボタン押下時にエラーとなる件の対応

@HanaLucky/KPTer
