### PR TITLE
tryカードのタイトル、詳細のフォントカラーをKeep, Problemに合わせた

### DIFF
--- a/KPTer/TryCardTableViewCell.swift
+++ b/KPTer/TryCardTableViewCell.swift
@@ -25,6 +25,14 @@ class TryCardTableViewCell: CardTableViewCell {
         self.status.offAnimationType = BEMAnimationType.Bounce
     }
     
+    override func setSelected(selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+        // Configure the view for the selected state
+        // cellに対し、UIFlatKit適応
+        self.title.textColor = UIColor(red: 56/255, green: 56/255, blue: 56/255, alpha: 1.0)
+        self.detail.textColor = UIColor(red: 56/255, green: 56/255, blue: 56/255, alpha: 1.0)
+    }
+    
     override func setCell (card: Card) {
         self.title.text = card.card_title
         self.detail.text = card.detail


### PR DESCRIPTION
Fixes #159.

Changes proposed in this pull request:
-  tryカードのタイトル、詳細のフォントカラーをKeep, Problemに合わせた

@HanaLucky/KPTer
